### PR TITLE
feat: Improve UI layout for small screens

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
     <link href="./assets/fonts/material-symbols.css" rel="stylesheet">
 </head>
 
-<body class="bg-[var(--md-background)] text-[var(--md-on-background)]">
+<body class="bg-[var(--md-background)] text-[var(--md-on-background)] min-h-screen overflow-y-auto">
     <!-- トップアプリバー -->
     <header class="md-top-app-bar">
         <div class="md-top-app-bar-row">
@@ -58,7 +58,7 @@
         </div>
     </header>
 
-    <main class="container mx-auto max-w-3xl p-5 pt-20">
+    <main class="container mx-auto max-w-3xl p-5 pt-8 pb-32">
         <!-- エラーメッセージ用スナックバー (初期状態は非表示) -->
         <div id="error" class="hidden"></div>
 


### PR DESCRIPTION
- Add `min-h-screen` and `overflow-y-auto` to body for proper scrolling on small screens.
- Adjust `main` padding-top from `pt-20` to `pt-8` and add `pb-32` to accommodate the fixed footer.
